### PR TITLE
Specify asset dependencies for sprockets

### DIFF
--- a/vendor/assets/stylesheets/chosen.css.scss
+++ b/vendor/assets/stylesheets/chosen.css.scss
@@ -2,6 +2,9 @@
 @import "compass/css3/images";
 @import "compass/css3/user-interface";
 
+//= depend_on_asset "chosen-sprite.png"
+//= depend_on_asset "chosen-sprite@2x.png"
+
 $chosen-sprite: image-url('chosen-sprite.png') !default;
 $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 


### PR DESCRIPTION
`better_sprockets_errors` reports that chosen.css.scss doesn't declare its assets properly. Adding these will make the CSS work better with Sprockets :)